### PR TITLE
Do not remove text if key isn't in messages.json

### DIFF
--- a/l10n.js
+++ b/l10n.js
@@ -8,7 +8,7 @@ var l10n = {
 	updateString(aString) {
 		return aString.replace(/__MSG_(.+?)__/g, function(aMatched) {
 			var key = aMatched.slice(6, -2);
-			return chrome.i18n.getMessage(key);
+			return chrome.i18n.getMessage(key) || aMatched;
 		});
 	},
 


### PR DESCRIPTION
If used with non-existent key (e.g. because of a typo), keep the `__MSG_...` in place, so it can be noticed and fixed easier.