### PR TITLE
More restrictive RegEx

### DIFF
--- a/l10n.js
+++ b/l10n.js
@@ -6,7 +6,7 @@
 
 var l10n = {
   updateString(string) {
-    return string.replace(/__MSG_(.+?)__/g, matched => {
+    return string.replace(/__MSG_([@\w]+)__/g, matched => {
       const key = matched.slice(6, -2);
       return chrome.i18n.getMessage(key) || matched;
     });


### PR DESCRIPTION
[According to MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference) only a limited set of characters is allowed in message names. So a more restrictive RegEx might be better.